### PR TITLE
Add missing package gawk

### DIFF
--- a/scripts/init_env.sh
+++ b/scripts/init_env.sh
@@ -6,6 +6,6 @@ chmod a+w /etc/apt/sources.list
 echo "deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription" >>/etc/apt/sources.list
 echo "deb http://deb.debian.org/debian bookworm main" >>/etc/apt/sources.list
 apt-get update
-apt-get install git nano screen patch fakeroot build-essential devscripts libncurses5 libncurses5-dev libssl-dev bc flex bison libelf-dev libaudit-dev libgtk2.0-dev libperl-dev asciidoc xmlto gnupg gnupg2 rsync lintian debhelper libdw-dev libnuma-dev libslang2-dev sphinx-common asciidoc-base automake cpio dh-python file gcc kmod libiberty-dev libtool python3-minimal sed tar zlib1g-dev liblz4-tool idn zstd libpve-common-perl systemtap-sdt-dev libcap-dev libzstd-dev libtraceevent-dev libunwind-dev python3-dev binutils-dev dwarves python3-setuptools libpfm4-dev
+apt-get install git nano screen patch fakeroot build-essential devscripts libncurses5 libncurses5-dev libssl-dev bc flex bison libelf-dev libaudit-dev libgtk2.0-dev libperl-dev asciidoc xmlto gnupg gnupg2 rsync lintian debhelper libdw-dev libnuma-dev libslang2-dev sphinx-common asciidoc-base automake cpio dh-python file gcc kmod libiberty-dev libtool python3-minimal sed tar zlib1g-dev liblz4-tool idn zstd libpve-common-perl systemtap-sdt-dev libcap-dev libzstd-dev libtraceevent-dev libunwind-dev python3-dev binutils-dev dwarves python3-setuptools libpfm4-dev gawk
 apt-get autoremove --purge
 apt-get clean


### PR DESCRIPTION
Fix error gawk not found

```
/bin/sh: 1: gawk: not found
  GEN     modules.builtin.ranges
make[4]: *** [scripts/Makefile.vmlinux:93: modules.builtin.ranges] Error 127
make[4]: *** Deleting file 'modules.builtin.ranges'
make[3]: *** [/home/build/pve-kernel/proxmox-kernel-6.14.0/ubuntu-kernel/Makefile:1234: vmlinux] Error 2
make[2]: Leaving directory '/home/build/pve-kernel/proxmox-kernel-6.14.0/ubuntu-kernel'
make[2]: *** [Makefile:251: __sub-make] Error 2
make[1]: *** [debian/rules:164: .compile_mark] Error 2
make[1]: Leaving directory '/home/build/pve-kernel/proxmox-kernel-6.14.0'
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
make: *** [Makefile:63: proxmox-kernel-6.14.0-1-pve_6.14.0-1_amd64.deb] Error 2
Error: Process completed with exit code 2.
```